### PR TITLE
Always print the detailed report on audit

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -313,8 +313,6 @@ pub fn run(config: Config, owners: Vec<Box<dyn Signer>>, mints: Option<Vec<Pubke
     .unwrap();
 
     report.summary(std::io::stdout()).unwrap();
-    if config.verbose {
-        println!();
-        report.detail(std::io::stdout()).unwrap();
-    }
+    println!();
+    report.detail(std::io::stdout()).unwrap();
 }


### PR DESCRIPTION
Normally we only print the detailed report with the `-v` flag, but let's just print the whole thing out always.