### PR TITLE
Add genesis check and option to disable the check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/test-ledger

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -53,7 +53,8 @@ mod tests {
 
     #[test]
     fn test_cleanup_delegation() {
-        let rpc_client = RpcClient::new("https://api.mainnet-beta.solana.com/".to_string());
+        let json_rpc_url = "https://api.mainnet-beta.solana.com".to_string();
+        let rpc_client = RpcClient::new(json_rpc_url.clone());
         let wallet = NullSigner::new(
             &Pubkey::from_str("EriSViggFFQ72fYgCKYyattiY3rDsx9bnMgMUpGa5x2H").unwrap(),
         );
@@ -63,6 +64,7 @@ mod tests {
         let mint = Pubkey::from_str("4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R").unwrap();
         let delegate = Pubkey::from_str("BaDmyYaaua9k8mZuL53UUt8E6peRMeT3cRVjYcLm68T7").unwrap();
         let config = Config {
+            json_rpc_url,
             rpc_client,
             fee_payer,
             dry_run: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use {solana_client::rpc_client::RpcClient, solana_sdk::signature::Signer};
 
 pub struct Config {
     pub rpc_client: RpcClient,
+    pub json_rpc_url: String,
     pub fee_payer: Box<dyn Signer>,
     pub dry_run: bool,
     pub verbose: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,13 @@ mod tests {
 
     #[test]
     fn test_for_all_spl_token_accounts() {
-        let rpc_client = RpcClient::new("https://api.mainnet-beta.solana.com".to_string());
+        let json_rpc_url = "https://api.mainnet-beta.solana.com".to_string();
+        let rpc_client = RpcClient::new(json_rpc_url.clone());
         let fee_payer = Box::new(NullSigner::new(
             &Pubkey::from_str("EriSViggFFQ72fYgCKYyattiY3rDsx9bnMgMUpGa5x2H").unwrap(),
         ));
         let config = Config {
+            json_rpc_url,
             rpc_client,
             fee_payer,
             dry_run: true,


### PR DESCRIPTION
#### Problem

We can be pointed at RPC which doesn't have enough transaction data, giving us false negatives during the audit.

#### Solution

Checks that the first available block is 1 (the first for solana-test-validator) or 0 (first from api.mainnet-beta.solana.com), with the option to disable the check with `skip-genesis-block-check`.

I wonder if this will be too aggressive -- for example, was spl-token even deployed at slot 0? On the flip side, people can be sure that they're fully searching the history of all transactions for anything shady.